### PR TITLE
Extend to Allow Custom Navigation View and Page Listener

### DIFF
--- a/allaboard/src/main/java/me/tylerbwong/allaboard/builder/OnboardingBuilder.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/builder/OnboardingBuilder.kt
@@ -1,20 +1,23 @@
 package me.tylerbwong.allaboard.builder
 
 import android.app.Activity
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorRes
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
+import androidx.viewpager.widget.ViewPager
 import me.tylerbwong.allaboard.view.OnboardingView
+import me.tylerbwong.allaboard.view.PageNavigator
 import me.tylerbwong.allaboard.view.PageView
 
-fun Activity.onboarding(setup: OnboardingBuilder.() -> Unit = {}): OnboardingView {
+fun Activity.onboarding(setup: OnboardingBuilder.() -> Unit): PageNavigator {
     val builder = OnboardingBuilder(this)
     builder.setup()
     return builder.build()
 }
 
-fun Fragment.onboarding(setup: OnboardingBuilder.() -> Unit = {}): OnboardingView {
+fun Fragment.onboarding(setup: OnboardingBuilder.() -> Unit): PageNavigator {
     val fragmentActivity = activity
             ?: throw IllegalStateException("Fragment is not attached to an Activity!")
     val builder = OnboardingBuilder(fragmentActivity)
@@ -27,13 +30,23 @@ class OnboardingBuilder(activity: Activity) {
     @ColorRes
     var backgroundColor: Int? = null
     var showIndicator: Boolean = true
+    var navigationView: View? = null
+    var onPageChangeListener: ViewPager.OnPageChangeListener? = null
     private val pages: MutableList<PageView> = mutableListOf()
     private var onFinishHandler: (() -> Unit)? = null
 
     private val rootView: ViewGroup = ActivityCompat.requireViewById(activity, android.R.id.content)
 
-    internal fun build() = OnboardingView(
+    fun onFinish(handler: () -> Unit) {
+        onFinishHandler = handler
+    }
+
+    internal fun addPage(page: PageView) = pages.add(page)
+
+    internal fun build(): PageNavigator = OnboardingView(
             rootView,
+            navigationView,
+            onPageChangeListener,
             backgroundColor,
             showIndicator,
             pages,
@@ -47,10 +60,4 @@ class OnboardingBuilder(activity: Activity) {
     @Deprecated(level = DeprecationLevel.ERROR, message = "Onboardings can't be nested.")
     fun onboarding(param: () -> Unit = {}) {
     }
-
-    fun onFinish(handler: () -> Unit) {
-        onFinishHandler = handler
-    }
-
-    internal fun addPage(page: PageView) = pages.add(page)
 }

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/builder/PageBuilder.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/builder/PageBuilder.kt
@@ -7,10 +7,10 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import me.tylerbwong.allaboard.view.PageView
 
-fun OnboardingBuilder.page(setup: PageBuilder.() -> Unit): PageView {
+fun OnboardingBuilder.page(setup: PageBuilder.() -> Unit) {
     val page = PageBuilder()
     page.setup()
-    return page.build().also { addPage(it) }
+    page.build().also { addPage(it) }
 }
 
 @AllAboardDsl
@@ -68,4 +68,4 @@ class PageBuilder {
 }
 
 @DslMarker
-annotation class AllAboardDsl
+internal annotation class AllAboardDsl

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/NavigationView.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/NavigationView.kt
@@ -1,0 +1,89 @@
+package me.tylerbwong.allaboard.view
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.OvershootInterpolator
+import android.widget.ImageButton
+import androidx.annotation.DrawableRes
+import androidx.core.view.ViewCompat
+import androidx.viewpager.widget.ViewPager
+import me.tylerbwong.allaboard.R
+
+internal class NavigationView(
+        rootView: ViewGroup,
+        private val numPages: Int,
+        private val pageNavigator: PageNavigator
+) : ViewPager.OnPageChangeListener {
+    private val skipPrevButton = ViewCompat.requireViewById<ImageButton>(rootView, R.id.prev_button)
+    private val nextDoneButton = ViewCompat.requireViewById<ImageButton>(rootView, R.id.next_button)
+    private val interpolator = OvershootInterpolator()
+    private var isLastPage = false
+
+    init {
+        skipPrevButton.apply {
+            background.alpha = BUTTON_ALPHA
+            setOnClickListener { pageNavigator.goToPrevious() }
+        }
+
+        nextDoneButton.apply {
+            background.alpha = BUTTON_ALPHA
+            setOnClickListener { pageNavigator.goToNext() }
+        }
+    }
+
+    override fun onPageSelected(position: Int) {
+        if (position == numPages - 1) {
+            isLastPage = true
+            animate(
+                    nextDoneButton,
+                    R.drawable.ic_check_white_24dp,
+                    FULL_ROTATION,
+                    LONG_ROTATION_DURATION
+            )
+        } else {
+            if (isLastPage) {
+                isLastPage = false
+                animate(
+                        nextDoneButton,
+                        R.drawable.ic_arrow_forward_white_24dp,
+                        REVERSE_FULL_ROTATION,
+                        LONG_ROTATION_DURATION
+                )
+            }
+        }
+
+        if (position == 0) {
+            skipPrevButton.visibility = View.INVISIBLE
+        } else {
+            skipPrevButton.visibility = View.VISIBLE
+        }
+    }
+
+    override fun onPageScrollStateChanged(state: Int) {
+    }
+
+    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+    }
+
+    private fun animate(
+            button: ImageButton,
+            @DrawableRes toIcon: Int,
+            rotation: Float,
+            duration: Long
+    ) {
+        button.setImageResource(toIcon)
+        ViewCompat.animate(button)
+                .rotation(rotation)
+                .withLayer()
+                .setDuration(duration)
+                .setInterpolator(interpolator)
+                .start()
+    }
+
+    companion object {
+        private const val FULL_ROTATION = 360.0f
+        private const val REVERSE_FULL_ROTATION = 0.0f
+        private const val LONG_ROTATION_DURATION: Long = 1000
+        private const val BUTTON_ALPHA = 72
+    }
+}

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/OnPageChangeListenerAdapter.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/OnPageChangeListenerAdapter.kt
@@ -1,0 +1,17 @@
+package me.tylerbwong.allaboard.view
+
+import androidx.viewpager.widget.ViewPager
+
+abstract class OnPageChangeListenerAdapter : ViewPager.OnPageChangeListener {
+    override fun onPageScrollStateChanged(state: Int) {
+        // Sub-classes may override
+    }
+
+    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+        // Sub-classes may override
+    }
+
+    override fun onPageSelected(position: Int) {
+        // Sub-classes may override
+    }
+}

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/OnboardingView.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/OnboardingView.kt
@@ -2,45 +2,30 @@ package me.tylerbwong.allaboard.view
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
 import me.tylerbwong.allaboard.R
-import android.view.animation.OvershootInterpolator
 import androidx.annotation.ColorRes
-import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
 
-class OnboardingView internal constructor(
+internal class OnboardingView(
         rootView: ViewGroup,
-        @ColorRes private var backgroundColor: Int? = null,
-        private var showIndicator: Boolean = true,
+        navigationView: View? = null,
+        onPageChangeListener: ViewPager.OnPageChangeListener? = null,
+        @ColorRes private val backgroundColor: Int? = null,
+        private val showIndicator: Boolean = true,
         private val pages: MutableList<PageView> = mutableListOf(),
-        private var onFinishHandler: (() -> Unit)? = null
-) : ViewPager.OnPageChangeListener {
+        private val onFinishHandler: (() -> Unit)? = null
+) : PageNavigator {
     private val onboardingView = rootView.inflateAndAttach(R.layout.onboarding_view)
+    private val navigationContainer = ViewCompat.requireViewById<ViewGroup>(onboardingView, R.id.navigation_container)
     private val viewPager = ViewCompat.requireViewById<ViewPager>(onboardingView, R.id.view_pager)
     private val tabDots = ViewCompat.requireViewById<TabLayout>(onboardingView, R.id.dot_tabs)
-    private val skipPrevButton = ViewCompat.requireViewById<ImageButton>(
-            onboardingView,
-            R.id.prev_button
-    )
-    private val nextDoneButton = ViewCompat.requireViewById<ImageButton>(
-            onboardingView,
-            R.id.next_button
-    )
-    private val interpolator = OvershootInterpolator()
-    private var isLastPage = false
 
     init {
         backgroundColor?.let {
             onboardingView.setBackgroundColor(ContextCompat.getColor(rootView.context, it))
-        }
-
-        viewPager.apply {
-            adapter = OnboardingPagerAdapter(pages)
-            addOnPageChangeListener(this@OnboardingView)
         }
 
         tabDots.apply {
@@ -48,83 +33,36 @@ class OnboardingView internal constructor(
             visibility = if (showIndicator) View.VISIBLE else View.GONE
         }
 
-        skipPrevButton.apply {
-            background.alpha = BUTTON_ALPHA
-            setOnClickListener {
-                viewPager.currentItem = viewPager.currentItem - 1
-            }
+        if (navigationView != null) {
+            navigationContainer.addView(navigationView)
+        } else {
+            val defaultNavigationView = navigationContainer.inflateAndAttach(R.layout.navigation_view)
+            val navigation = NavigationView(defaultNavigationView as ViewGroup, pages.size, this)
+            viewPager.addOnPageChangeListener(navigation)
         }
 
-        nextDoneButton.apply {
-            background.alpha = BUTTON_ALPHA
-            setOnClickListener {
-                val curItem = viewPager.currentItem
+        if (onPageChangeListener != null) {
+            viewPager.addOnPageChangeListener(onPageChangeListener)
+        }
 
-                if (curItem < pages.size - 1) {
-                    viewPager.currentItem = curItem + 1
-                }
-                else {
-                    onFinishHandler?.invoke()
-                }
-            }
+        viewPager.adapter = OnboardingPagerAdapter(pages)
+    }
+
+    override fun goToPrevious() {
+        viewPager.currentItem = viewPager.currentItem - 1
+    }
+
+    override fun goToNext() {
+        val curItem = viewPager.currentItem
+
+        if (curItem < pages.size - 1) {
+            viewPager.currentItem = curItem + 1
+        } else {
+            finish()
         }
     }
 
-    override fun onPageSelected(position: Int) {
-        if (position == pages.size - 1) {
-            isLastPage = true
-            animate(
-                    nextDoneButton,
-                    R.drawable.ic_check_white_24dp,
-                    FULL_ROTATION,
-                    LONG_ROTATION_DURATION
-            )
-        }
-        else {
-            if (isLastPage) {
-                isLastPage = false
-                animate(
-                        nextDoneButton,
-                        R.drawable.ic_arrow_forward_white_24dp,
-                        REVERSE_FULL_ROTATION,
-                        LONG_ROTATION_DURATION
-                )
-            }
-        }
-
-        if (position == 0) {
-            skipPrevButton.visibility = View.INVISIBLE
-        }
-        else {
-            skipPrevButton.visibility = View.VISIBLE
-        }
-    }
-
-    override fun onPageScrollStateChanged(state: Int) {
-    }
-
-    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-    }
-
-    private fun animate(
-            button: ImageButton,
-            @DrawableRes toIcon: Int,
-            rotation: Float,
-            duration: Long
-    ) {
-        button.setImageResource(toIcon)
-        ViewCompat.animate(button)
-                .rotation(rotation)
-                .withLayer()
-                .setDuration(duration)
-                .setInterpolator(interpolator)
-                .start()
-    }
-
-    companion object {
-        private const val FULL_ROTATION = 360.0f
-        private const val REVERSE_FULL_ROTATION = 0.0f
-        private const val LONG_ROTATION_DURATION: Long = 1000
-        private const val BUTTON_ALPHA = 72
+    override fun finish() {
+        onFinishHandler?.invoke()
     }
 }

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/PageNavigator.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/PageNavigator.kt
@@ -1,0 +1,7 @@
+package me.tylerbwong.allaboard.view
+
+interface PageNavigator {
+    fun goToPrevious()
+    fun goToNext()
+    fun finish()
+}

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/PageView.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/PageView.kt
@@ -14,7 +14,7 @@ import com.airbnb.lottie.LottieDrawable
 import com.bumptech.glide.Glide
 import me.tylerbwong.allaboard.R
 
-class PageView internal constructor(
+internal class PageView(
         private var imageUrl: String? = null,
         private var lottieFile: String? = null,
         @DrawableRes private var imageRes: Int? = null,
@@ -27,6 +27,21 @@ class PageView internal constructor(
         private var customView: View? = null,
         @LayoutRes private var customViewRes: Int? = null
 ) {
+    internal fun getView(rootView: ViewGroup): View {
+        customView?.let {
+            return it
+        }
+        customViewRes?.let {
+            return rootView.justInflate(it)
+        }
+
+        return rootView.justInflate(R.layout.page_view).also {
+            ViewCompat.requireViewById<LottieAnimationView>(it, R.id.image).applyImage()
+            ViewCompat.requireViewById<TextView>(it, R.id.title).applyTitle()
+            ViewCompat.requireViewById<TextView>(it, R.id.sub_title).applySubTitle()
+        }
+    }
+
     private fun LottieAnimationView.applyImage() {
         imageUrl?.let {
             Glide.with(context)
@@ -71,20 +86,5 @@ class PageView internal constructor(
         }
 
         text = subTitleText
-    }
-
-    internal fun getView(rootView: ViewGroup): View {
-        customView?.let {
-            return it
-        }
-        customViewRes?.let {
-            return rootView.justInflate(it)
-        }
-
-        return rootView.justInflate(R.layout.page_view).also {
-            ViewCompat.requireViewById<LottieAnimationView>(it, R.id.image).applyImage()
-            ViewCompat.requireViewById<TextView>(it, R.id.title).applyTitle()
-            ViewCompat.requireViewById<TextView>(it, R.id.sub_title).applySubTitle()
-        }
     }
 }

--- a/allaboard/src/main/java/me/tylerbwong/allaboard/view/ViewGroupUtils.kt
+++ b/allaboard/src/main/java/me/tylerbwong/allaboard/view/ViewGroupUtils.kt
@@ -5,8 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 
-fun ViewGroup.inflateAndAttach(@LayoutRes resource: Int): View = LayoutInflater.from(context)
+internal fun ViewGroup.inflateAndAttach(@LayoutRes resource: Int): View = LayoutInflater.from(context)
         .inflate(resource, this)
 
-fun ViewGroup.justInflate(@LayoutRes resource: Int): View = LayoutInflater.from(context)
+internal fun ViewGroup.justInflate(@LayoutRes resource: Int): View = LayoutInflater.from(context)
         .inflate(resource, this, false)

--- a/allaboard/src/main/res/layout/navigation_view.xml
+++ b/allaboard/src/main/res/layout/navigation_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="32dp">
+
+    <ImageButton
+        android:id="@+id/prev_button"
+        android:layout_width="@dimen/round_button_size"
+        android:layout_height="@dimen/round_button_size"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:background="@drawable/round_button"
+        android:gravity="end"
+        android:rotation="180"
+        android:visibility="invisible"
+        app:srcCompat="@drawable/ic_arrow_forward_white_24dp"
+        tools:ignore="ContentDescription" />
+
+    <ImageButton
+        android:id="@+id/next_button"
+        android:layout_width="@dimen/round_button_size"
+        android:layout_height="@dimen/round_button_size"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:background="@drawable/round_button"
+        android:gravity="end"
+        app:srcCompat="@drawable/ic_arrow_forward_white_24dp"
+        tools:ignore="ContentDescription" />
+</RelativeLayout>

--- a/allaboard/src/main/res/layout/onboarding_view.xml
+++ b/allaboard/src/main/res/layout/onboarding_view.xml
@@ -1,60 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/bottom_bar" />
+        android:layout_above="@+id/navigation_container" />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/dot_tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/bottom_bar"
+        android:layout_above="@+id/navigation_container"
         app:tabBackground="@drawable/tab_dot_selector"
         app:tabGravity="center"
         app:tabIndicatorHeight="0dp"
         app:tabPaddingEnd="8dp"
         app:tabPaddingStart="8dp" />
 
-    <RelativeLayout
-        android:id="@+id/bottom_bar"
+    <FrameLayout
+        android:id="@+id/navigation_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="32dp"
-        android:layout_marginEnd="32dp"
-        android:layout_marginLeft="32dp"
-        android:layout_marginRight="32dp"
-        android:layout_marginStart="32dp">
-
-        <ImageButton
-            android:id="@+id/prev_button"
-            android:layout_width="@dimen/round_button_size"
-            android:layout_height="@dimen/round_button_size"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:background="@drawable/round_button"
-            android:gravity="end"
-            android:rotation="180"
-            android:visibility="invisible"
-            app:srcCompat="@drawable/ic_arrow_forward_white_24dp"
-            tools:ignore="ContentDescription" />
-
-        <ImageButton
-            android:id="@+id/next_button"
-            android:layout_width="@dimen/round_button_size"
-            android:layout_height="@dimen/round_button_size"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:background="@drawable/round_button"
-            android:gravity="end"
-            app:srcCompat="@drawable/ic_arrow_forward_white_24dp"
-            tools:ignore="ContentDescription" />
-    </RelativeLayout>
+        android:layout_alignParentBottom="true" />
 </RelativeLayout>

--- a/allaboard/src/main/res/layout/page_view.xml
+++ b/allaboard/src/main/res/layout/page_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -32,10 +33,7 @@
         android:id="@+id/sub_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginStart="16dp"
+        android:layout_margin="16dp"
         android:gravity="center"
         android:maxLines="3"
         android:textColor="@android:color/white"

--- a/app/src/main/java/me/tylerbwong/allaboardexample/AllAboardActivity.kt
+++ b/app/src/main/java/me/tylerbwong/allaboardexample/AllAboardActivity.kt
@@ -3,10 +3,13 @@ package me.tylerbwong.allaboardexample
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import me.tylerbwong.allaboard.builder.onboarding
 import me.tylerbwong.allaboard.builder.page
+import me.tylerbwong.allaboard.view.OnPageChangeListenerAdapter
 
 class AllAboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -18,10 +21,28 @@ class AllAboardActivity : AppCompatActivity() {
                         window.decorView.rootView as ViewGroup,
                         false
                 )
+        val customNavigationView = LayoutInflater.from(this)
+                .inflate(
+                        R.layout.custom_navigation_view,
+                        window.decorView.rootView as ViewGroup,
+                        false
+                )
+        val skipButton = ViewCompat.requireViewById<Button>(customNavigationView, R.id.skip_button)
+        val nextDoneButton = ViewCompat.requireViewById<Button>(customNavigationView, R.id.next_button)
 
-        onboarding {
+        val pageNavigator = onboarding {
             backgroundColor = R.color.colorPrimary
             showIndicator = true
+            onPageChangeListener = object : OnPageChangeListenerAdapter() {
+                override fun onPageSelected(position: Int) {
+                    Toast.makeText(
+                            this@AllAboardActivity,
+                            "Showing page number $position",
+                            Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+            navigationView = customNavigationView
 
             page {
                 imageRes = R.drawable.train
@@ -51,5 +72,7 @@ class AllAboardActivity : AppCompatActivity() {
                 ).show()
             }
         }
+        skipButton.setOnClickListener { pageNavigator.finish() }
+        nextDoneButton.setOnClickListener { pageNavigator.goToNext() }
     }
 }

--- a/app/src/main/res/layout/activity_all_aboard.xml
+++ b/app/src/main/res/layout/activity_all_aboard.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             android:id="@+id/container"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent"
-             android:orientation="vertical"/>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" />

--- a/app/src/main/res/layout/custom_navigation_view.xml
+++ b/app/src/main/res/layout/custom_navigation_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="32dp">
+
+    <Button
+        android:id="@+id/skip_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:gravity="center"
+        android:text="Skip"
+        tools:ignore="ContentDescription" />
+
+    <Button
+        android:id="@+id/next_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:gravity="center"
+        android:text="Next"
+        tools:ignore="ContentDescription" />
+</RelativeLayout>

--- a/app/src/main/res/layout/page_four.xml
+++ b/app/src/main/res/layout/page_four.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:gravity="center"
-              android:orientation="vertical">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
 
     <ImageView
         android:layout_width="200dp"

--- a/app/src/main/res/layout/page_three.xml
+++ b/app/src/main/res/layout/page_three.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"


### PR DESCRIPTION
Closes #2.

This adds two new customizable options to the `onboarding` block: `onPageChangeListener` and `navigationView`. It also now returns a `PageNavigator` which will allow programmatically switching between pages in the onboarding flow.

Example:
```kt
val navigator = onboarding {
    ...
    onPageChangeListener = object : OnPageChangeListenerAdapter() {
        ...
    }
    navigationView = ... // Some custom view

    page {
        ...
    }
}
nextButton.setOnClickListener { navigator.goToNext() }
skipButton.setOnClickListener { navigator.finish() }
```

If no custom `navigationView` is provided, it will default to the original two button functionality that is now extracted out into a `NavigationView` class.